### PR TITLE
バグ修正

### DIFF
--- a/バッチ開発補助/scripts/func/conf/func_java_common.sh
+++ b/バッチ開発補助/scripts/func/conf/func_java_common.sh
@@ -26,7 +26,7 @@ SET_RUNTIME_CLASSPATH () {
 
     ### ジョブ単位でコピーされるJAR対応
     for JAR_RUN_LIB in "${RUN_LIB_OUT_DIR}"/*; do
-        RUNTIME_CLASSPATH="${RUN_LIB_OUT_DIR}/${JAR_RUN_LIB}:${RUNTIME_CLASSPATH}"
+        RUNTIME_CLASSPATH="${JAR_RUN_LIB}:${RUNTIME_CLASSPATH}"
     done
 
     for JAR_LIB in $(echo "${LIB_PATH}" | sed -e "s/:/\n/g"); do

--- a/バッチ開発補助/scripts/func/func_get.sh
+++ b/バッチ開発補助/scripts/func/func_get.sh
@@ -87,7 +87,7 @@ if [ ! -d "${TO_DIR}" ]; then
     LOG_MSG "${ES9999Z04}"
     LOG_MSG "PATH = ${TO_DIR}"
     LOG_MSG "EXIT_CODE = [113]"
-    exit 112
+    exit 113
 fi
 
 ### キーファイルの存在チェック


### PR DESCRIPTION
- https://github.com/nablarch-development-standards/nablarch-development-standards-tools/commit/4e7b6d49e8a28e8568354aebedb910636cb243d0
  - ログでは 113 を返すと出力しているのに、実際は 112 を返していたバグ
  - 113 を返すように修正
- https://github.com/nablarch-development-standards/nablarch-development-standards-tools/commit/32d409664564c7d1f61cc3acb513ac3c1031a651
  - ShellCheck 対応をしたときに埋め込まれたバグの修正
  - もともと `JAR_RUN_LIB` にはファイル名だけが設定されるようなループ方法だったが、ShellCheck対応でループ方法を変えたことで頭に `RUN_LIB_OUT_DIR` 必要がなくなった