### PR TITLE
JakartaEE10対応で、JavaEE由来の表現を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Nablarch開発プロセスを支援するツール群です。
 
 ### Mavenリポジトリで管理しているもの
 
-* JSP静的解析ツール
+* Jakarta Server Pages静的解析ツール
 
     [Nablarch Testing](https://mvnrepository.com/artifact/com.nablarch.framework/nablarch-testing)に同梱
     
@@ -90,14 +90,6 @@ Nablarch開発プロセスを支援するツール群です。
     
     [ツールのガイド](https://nablarch.github.io/docs/LATEST/doc/development_tools/toolbox/SqlExecutor/SqlExecutor.html)
   
-* 業務画面JSP検証ツール
-
-    業務画面JSPの検証を行うツールです。
-    [nablarch/nablarch-toolbox](https://github.com/nablarch/nablarch-toolbox)
-    
-    [ツールのガイド](https://nablarch.github.io/docs/LATEST/doc/development_tools/toolbox/JspVerifier/JspVerifier.html)
-
-
 
 ## ライセンス
 この作品は、Apache License 2.0 で提供されます。

--- a/en/README.md
+++ b/en/README.md
@@ -57,7 +57,7 @@ Automatically generates domain setting Java class files based on the domain defi
 
 ### Tools managed in the Maven repository
 
-* JSP static analysis tool (Bundled with [Nablarch Testing](https://mvnrepository.com/artifact/com.nablarch.framework/nablarch-testing))  
+* Jakarta Server Pages static analysis tool (Bundled with [Nablarch Testing](https://mvnrepository.com/artifact/com.nablarch.framework/nablarch-testing))  
 [Tool guide](https://nablarch.github.io/docs/LATEST/doc/en/development_tools/toolbox/JspStaticAnalysis/index.html)
   
 
@@ -71,10 +71,6 @@ This tool automates DBA routine work so that programmers can concentrating on th
  This tool interactively executes SQL files containing Nablarch's special syntax.    
 [Tool guide](https://nablarch.github.io/docs/LATEST/doc/en/development_tools/toolbox/SqlExecutor/SqlExecutor.html)
   
-* Business screen JSP verification tool ([nablarch/nablarch-toolbox](https://github.com/nablarch/nablarch-toolbox/tree/master/en))  
-This tool verifies business screen JSP.    
-[Tool guide](https://nablarch.github.io/docs/LATEST/doc/en/development_tools/toolbox/JspVerifier/JspVerifier.html)
-
 
 
 ## Licensing


### PR DESCRIPTION
- 「JSP静的解析ツール」を「Jakarta Server Pages静的解析ツール」に変更
- 「業務画面JSP検証ツール」の記載を削除